### PR TITLE
auto-reload-event-page-when-second-user-also-flakes

### DIFF
--- a/app/events/[event_id].tsx
+++ b/app/events/[event_id].tsx
@@ -73,12 +73,18 @@ export default function EventPage() {
         console.log("user set as the host")
       }
       if (user === fetchedEvent.created_by && fetchedEvent.host_flaked === true) {
-        console.log("confirmedflake because user flaked and user is host")
+        console.log("user is the host and has flaked")
         setConfirmedFlake(true)
       }
       if (user === fetchedEvent.invited && fetchedEvent.invitee_flaked === true) {
-        console.log("confirmedflake because user flaked and user is invitee")
+        console.log("user is the invitee and has flaked")
         setConfirmedFlake(true)
+      }
+      if (user !== fetchedEvent.created_by && fetchedEvent.host_flaked === true) {
+        setOtherHasFlaked(true)
+      }
+      if (user !== fetchedEvent.invited && fetchedEvent.invitee_flaked === true) {
+        setOtherHasFlaked(true)
       }
       if (fetchedEvent.host_flaked && fetchedEvent.invitee_flaked) {
         setBothFlaked(true)
@@ -172,6 +178,8 @@ export default function EventPage() {
               confirmedFlake={confirmedFlake}
               setConfirmedFlake={setConfirmedFlake}
               invitee={event.invited}
+              otherHasFlaked={otherHasFlaked}
+              setBothFlaked={setBothFlaked}
             />
           </View>
         ) : (

--- a/components/NotFeelingItButton.tsx
+++ b/components/NotFeelingItButton.tsx
@@ -18,6 +18,8 @@ export default function NotFeelingItButton({
   event_id,
   role,
   invited,
+  otherHasFlaked,
+  setBothFlaked,
 }) {
   const [modalVisible, setModalVisible] = useState(false)
   // const [confirmedFlake, setconfirmedFlake] = useState(false)
@@ -25,6 +27,9 @@ export default function NotFeelingItButton({
   // Pass in a piece of state you can update when the button is confirmed to be pressed e.g. flakedConfirmed
 
   const confirmClick = () => {
+    if (otherHasFlaked) {
+      setBothFlaked(true)
+    }
     setConfirmedFlake(!confirmedFlake)
     addFlake(event_id, role)
     // func to update the event with the {invitee/host flaked}


### PR DESCRIPTION
event page automatically reloads if user clicks not-feeling-it-button and other user has already flaked