### PR TITLE
update event page without datafetch if both users flake

### DIFF
--- a/app/events/[event_id].tsx
+++ b/app/events/[event_id].tsx
@@ -62,6 +62,9 @@ export default function EventPage() {
   })
 
   useEffect(() => {
+    if (bothFlaked) {
+      return
+    }
     setIsLoading(true)
     getEventByEventID(event_id).then((fetchedEvent) => {
       setEvent(fetchedEvent)


### PR DESCRIPTION
updates the useEffect in event page to return before refetching the event data if both users have flaked